### PR TITLE
Parse matchers, Google Spreadsheets HTML preset

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -1,6 +1,6 @@
 var cssauron = require('cssauron');
 
-module.exports = cssauron({
+var matchSelector = cssauron({
   tag:      'nodeName.toLowerCase()',
   contents: 'textContent',
   id:       'id',
@@ -9,3 +9,10 @@ module.exports = cssauron({
   children: 'childeNodes',
   attr:     'getAttribute(attr)'
 });
+
+module.exports = function(selector) {
+  if (typeof selector === 'function') {
+    return selector;
+  }
+  return matchSelector(selector);
+};

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,14 +6,49 @@ var htmlparser = require('htmlparser2'),
     extend = require('extend'),
     through2 = require('through2');
 
+var presets = {
+  'google-html': {
+    headerRow: matcher('tbody tr'),
+    headerCell: matcher('td'),
+    contentRow: function(tr, i) {
+      // ugggghhhh, why do you make me do this, google?
+      return !tr.firstChild.className.match(/freezebar/);
+    },
+    contentCell: matcher('td')
+  }
+};
+
 module.exports = function parse(options) {
+  var log = options.verbose ? console.warn.bind(console) : noop;
+
+  if (typeof options === 'string') {
+    // if options is a string, assume it's a preset name
+    options = presets[options] || {};
+  } else if (options.preset) {
+    // otherwise, merge in options from the named preset
+    var preset = presets[options.preset];
+    if (preset) {
+      Object.keys(preset).forEach(function(key) {
+        if (!options.hasOwnProperty(key)) {
+          options[key] = preset[key];
+        }
+      });
+    } else {
+      log('no such preset: "%s"', options.preset);
+    }
+  }
+
   var columns = options.columns,
       rows = [],
-      node,
       stack = [],
-      root,
-      matches = matcher(options.selector || 'table'),
+      node,
+      table,
       done = false,
+      matchesTable = matcher(options.table || 'table'),
+      matchesHeaderRow = matcher(options.headerRow || 'tr'),
+      matchesHeaderCell = matcher(options.headerCell || 'th, td'),
+      matchesContentRow = matcher(options.contentRow || 'tr'),
+      matchesContentCell = matcher(options.contentCell || 'th, td'),
       parser = new htmlparser.Parser({
         onopentag: onopentag,
         ontext: ontext,
@@ -21,7 +56,7 @@ module.exports = function parse(options) {
       });
 
   function onopentag(name, attrs) {
-    // console.warn('<' + name + '>');
+    // log('<' + name + '>');
     if (node) stack.push(node);
     var parent = node;
     node = createNode(name, attrs);
@@ -29,10 +64,10 @@ module.exports = function parse(options) {
     if (parent) {
       parent.appendChild(node);
     }
-    if (!root) {
-      var match = matches(node);
+    if (!table) {
+      var match = matchesTable(node);
       if (match) {
-        root = node;
+        table = node;
       }
     }
   }
@@ -53,14 +88,14 @@ module.exports = function parse(options) {
   }
 
   function onclosetag(name) {
-    // console.warn('</' + name + '>');
+    // log('</' + name + '>');
     node.closed = true;
-    if (root) {
+    if (table) {
       processNode(node);
-      if (node === root) {
-        root = null;
+      if (node === table) {
+        table = null;
         done = true;
-        // console.warn('<--- inactive', node.nodeName, node.attributes);
+        // log('<--- inactive', node.nodeName, node.attributes);
       }
     }
     node = stack.pop();
@@ -69,41 +104,57 @@ module.exports = function parse(options) {
   function processNode(node) {
     switch (node.nodeName.toLowerCase()) {
       case 'br':
+        // append a line break to the node's text content, which will be
+        // collapsed into a space in clean()
         node.appendChild(document.createTextNode('\n'));
         return;
+
+      // if we've read a <thead>, this is probably where we want to get the header rows
       case 'thead':
         if (!columns) {
-          var rows = node.querySelectorAll('tr');
-          // console.warn('processing %d row(s) in <thead>...', rows.length);
-          columns = readColumns(rows);
+          var rows = node.querySelectorAll('tr').filter(matchesHeaderRow);
+          if (rows.length) {
+            log('processing %d row(s) in <thead>...', rows.length);
+            columns = readColumns(rows, matchesHeaderCell, log);
+            log('columns:', columns);
+          } else {
+            log('no matching rows in <thead>');
+          }
         }
         return;
+
       case 'tr':
-        return processRow(node);
+        processRow(node);
+        return;
+
       case 'th':
       case 'td':
+        // XXX filter here?
         return processCell(node);
     }
   }
 
   function processRow(tr) {
     if (!columns) {
-      if (tr.scoped || tr.parentNode.nodeName !== 'THEAD') {
-        columns = readColumns([tr]);
-        // console.warn('columns:', columns);
+      // if we haven't read any columns yet, assume that we'll get them from
+      // the first row
+      if (matchesHeaderRow(tr, getNodeIndex(tr))) {
+        log('reading columns from:', tr.outerHTML);
+        columns = readColumns([tr], matchesHeaderCell, log);
+        log('columns:', columns);
+        // log('columns:', columns);
       }
-    } else {
-      var row = readColumnsFromRow(tr, columns);
-      // console.warn('read row:', row);
+    } else if (matchesContentRow(tr, getNodeIndex(tr))) {
+      var row = readColumnsFromRow(tr, columns, matchesContentCell, log);
+      log('read row:', row);
       rows.push(row);
+    } else {
+      log('skipping row:', columns, tr.outerHTML);
     }
   }
 
   function processCell(el) {
-    if (el.getAttribute('scope') === 'col' && !el.parentNode.scoped) {
-      // console.warn('scoped row:', el.parentNode);
-      el.parentNode.scoped = true;
-    }
+    // XXX anything here?
   }
 
   return through2.obj(function(chunk, enc, next) {
@@ -114,18 +165,19 @@ module.exports = function parse(options) {
     next();
     if (done) this.end();
   });
-}
+};
 
-function readColumns(trs) {
+// export presets
+module.exports.presets = presets;
+
+function readColumns(trs, cellFilter, log) {
   var rows = [];
   trs.forEach(function(tr, i) {
     var row = rows[i] || (rows[i] = []),
         x = i,
         y = 0;
-    tr.querySelectorAll('td, th').forEach(function(cell, j) {
-      if (cell.nodeType !== 1) return;
-
-      // console.warn('read header:', cell.name, cell.textContent);
+    tr.querySelectorAll('th, td').filter(cellFilter || yes).forEach(function(cell, j) {
+      // log('read header:', cell.name, cell.textContent);
       var rowspan = +cell.getAttribute('rowspan') || 1,
           colspan = +cell.getAttribute('colspan') || 1,
           rowRange = range(x, x + rowspan);
@@ -163,22 +215,22 @@ function readColumns(trs) {
       if (!row[j]) continue;
       else if (row[j] === cols[j]) continue;
       else if (!cols[j]) cols[j] = row[j];
-      // console.warn('combining:', cols[j], 'with', row[j]);
+      // log('combining:', cols[j], 'with', row[j]);
       cols[j].text += ' ' + row[j].text;
     }
   }
-  // console.warn('columns:', JSON.stringify(cols, null, '  '));
+  // log('columns:', JSON.stringify(cols, null, '  '));
   return cols.map(function(d) { return d.text; });
 }
 
-function readColumnsFromRow(tr, columns) {
+function readColumnsFromRow(tr, columns, cellFilter, log) {
   var data = {};
   // TODO: account for colspan and rowspan
-  tr.querySelectorAll('td, th').forEach(function(cell, i) {
-    if (cell.nodeType !== 1) return;
+  tr.querySelectorAll('th, td').filter(cellFilter || yes).forEach(function(cell, i) {
     var key = columns[i];
+    var text = clean(cell.textContent);
     if (data.hasOwnProperty(key)) {
-      data[key] = [data[key], cell.text];
+      data[key] = [data[key], text];
     } else {
       data[key] = clean(cell.textContent);
     }
@@ -198,4 +250,23 @@ function range(a, b, step) {
   if (arguments.length < 3) step = 1;
   for (a; a < b; a += step) range.push(a);
   return range;
+}
+
+function getNodeIndex(node) {
+  var i = 0;
+  while (node = node.previousSibling) {
+    if (node.nodeType === 1) i++;
+  }
+  return i;
+}
+
+function yes() {
+  return true;
+}
+
+function no() {
+  return false;
+}
+
+function noop() {
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,11 +10,11 @@ var presets = {
   'google-html': {
     headerRow: matcher('tbody tr'),
     headerCell: matcher('td'),
-    contentRow: function(tr, i) {
+    bodyRow: function(tr, i) {
       // ugggghhhh, why do you make me do this, google?
       return !tr.firstChild.className.match(/freezebar/);
     },
-    contentCell: matcher('td')
+    bodyCell: matcher('td')
   }
 };
 
@@ -47,8 +47,8 @@ module.exports = function parse(options) {
       matchesTable = matcher(options.table || 'table'),
       matchesHeaderRow = matcher(options.headerRow || 'tr'),
       matchesHeaderCell = matcher(options.headerCell || 'th, td'),
-      matchesContentRow = matcher(options.contentRow || 'tr'),
-      matchesContentCell = matcher(options.contentCell || 'th, td'),
+      matchesContentRow = matcher(options.bodyRow || 'tr'),
+      matchesContentCell = matcher(options.bodyCell || 'th, td'),
       parser = new htmlparser.Parser({
         onopentag: onopentag,
         ontext: ontext,

--- a/test/html/google-html.html
+++ b/test/html/google-html.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html><html><head><title>public test spreadsheet</title><meta name="viewport" content="target-densitydpi=device-dpi,user-scalable=1,minimum-scale=1,maximum-scale=2.5,initial-scale=1,width=device-width">
+<link href='/static/spreadsheets2/client/css/275558636-waffle_k_ltr.css' type='text/css' rel='stylesheet'><style type="text/css">
+        html { overflow: visible; }
+        #sheets-viewport { overflow: auto; }
+        #sheets-viewport.widget-viewport { overflow: hidden; }
+        .grid-container { overflow: visible; background: white;}
+        .grid-table-container { overflow: visible; }
+        #top-bar {
+          background: url("//ssl.gstatic.com/docs/spreadsheets/publishheader.png") repeat-x bottom;
+          margin: 0;
+          overflow: hidden;
+        }
+        #top-bar {
+          border-bottom: 1px solid #ccc;
+          padding: 6px 6px 0;
+        }
+        #doc-title { padding-bottom: 5px; }
+        #doc-title .name { font-size: 15px; }
+        #sheet-menu {
+          font-size: 13px;
+          margin: 6px 0 0;
+          padding: 0 0 5px;
+        }
+        #sheet-menu li {
+          display: inline;
+          list-style-type: none;
+          margin: 0;
+          padding: 5px 8px;
+        }
+        #sheet-menu li.active {
+          background-color: #fff;
+          font-weight: bold;
+          border: 1px solid #999;
+        }
+        #top-bar #sheet-menu li.active {
+          border-bottom: 0;
+        }
+        #sheet-menu a, #sheet-menu a:visited { color: #07c; }
+        .ritz .waffle a { color: inherit; }.ritz .waffle .s1{text-align:right;color:#000000;background-color:#ffffff;font-size:10pt;vertical-align:bottom;white-space:nowrap;direction:ltr;padding:2px 3px 2px 3px;}.ritz .waffle .s0{text-align:right;font-weight:bold;color:#000000;background-color:#ffffff;font-size:10pt;vertical-align:bottom;white-space:nowrap;direction:ltr;padding:2px 3px 2px 3px;}</style><script type="text/javascript">
+        var activeSheetId;
+
+        function switchToSheet(id) {
+          if (document.getElementById('sheet-menu')) {
+            document.getElementById('sheet-button-' + activeSheetId)
+                .className = '';
+            document.getElementById('sheet-button-' + id).className = 'active';
+          }
+
+          document.getElementById(activeSheetId).style.display = 'none';
+          document.getElementById(id).style.display = '';
+          activeSheetId = id;
+
+          // posObjs() is defined in embeddedObjectJs (see EmbeddedObjectHtmlBuilder.java)
+          posObjs();
+          return false;
+        }
+        
+        function init() {
+        var optPageSwitcher;
+        
+        function resize() {
+          var optMobileWebHeader = document.getElementById('docs-ml-header-id');
+          var optTopBar = document.getElementById('top-bar');
+          var adjustedHeight = window.innerHeight -
+              (optMobileWebHeader ? optMobileWebHeader.offsetHeight : 0) -
+              (optTopBar ? optTopBar.offsetHeight : 0);
+          var adjustedWidth = window.innerWidth;
+          var sheetsViewport = document.getElementById('sheets-viewport');
+          sheetsViewport.style.width = (adjustedWidth + 'px');
+          sheetsViewport.style.height = (adjustedHeight + 'px');
+          if (optPageSwitcher) {
+            optPageSwitcher.resize(adjustedWidth, adjustedHeight);
+          }
+        }
+        resize();
+        window.onresize = resize;
+        }
+        </script><script>_docs_flag_initialData={"docs-sup":"/spreadsheets","drive_url":"//drive.google.com?usp\u003dsheets_web","docs-smheo":false,"info_params":{},"ilcm":{"eui":"ADFN-csPCJUvWNJ5E93Rag0X6SPs1gMhLkRvLl5xwia8vi_gLPyXPcROCF-dPQJh_C04rJ0727_k","je":1,"sstu":1430165193261000,"si":"CMj_wcKkl8UCFUPMMgodjVwA4w"}};</script></head><body onload=init()><div id="top-bar"><div id="doc-title"><span class="name">public test spreadsheet : Sheet1</span></div></div><div id="sheets-viewport"><div id="0" style="display:none;position:relative;" dir="ltr"><div class="ritz grid-container" dir="ltr"><table class="waffle" cellspacing="0" cellpadding="0"><thead><tr><th class="row-header freezebar-vertical-handle header-shim row-header-shim"></th><th id="0C0" style="width:100px" class="header-shim"></th><th id="0C1" style="width:100px" class="header-shim"></th><th id="0C2" style="width:100px" class="header-shim"></th></tr></thead><tbody><tr style='height:21px;'><th id="0R0" style="height: 21px;" class="row-headers-background row-header-shim"><div class="row-header-wrapper" style="line-height: 21px;">1</div></th><td class="s0">A</td><td class="s0">B</td><td class="s0">C</td></tr><tr><th style="height:4px" class="freezebar-cell freezebar-horizontal-handle row-header-shim"></th><td class="freezebar-cell"></td><td class="freezebar-cell"></td><td class="freezebar-cell"></td></tr><tr style='height:21px;'><th id="0R1" style="height: 21px;" class="row-headers-background row-header-shim"><div class="row-header-wrapper" style="line-height: 21px;">2</div></th><td class="s1">1</td><td class="s1">2</td><td class="s1">3</td></tr><tr style='height:21px;'><th id="0R2" style="height: 21px;" class="row-headers-background row-header-shim"><div class="row-header-wrapper" style="line-height: 21px;">3</div></th><td class="s1">x</td><td class="s1">y</td><td class="s1">z</td></tr></tbody></table></div></div></div>
+<script type='text/javascript'>
+function posObj(sheet, id, row, col, x, y) {
+  var rtl = false;
+  var sheetElement = document.getElementById(sheet);
+  if (!sheetElement) {
+    sheetElement = document.getElementById(sheet + '-grid-container');
+  }
+  if (sheetElement) {
+    rtl = sheetElement.getAttribute('dir') == 'rtl';
+  }
+  var r = document.getElementById(sheet+'R'+row);
+  var c = document.getElementById(sheet+'C'+col);
+  if (r && c) {
+    var objElement = document.getElementById(id);
+    var s = objElement.style;
+    var t = y;
+    while (r) {
+      t += r.offsetTop;
+      r = r.offsetParent;
+    }
+    var offsetX = x;
+    while (c) {
+      offsetX += c.offsetLeft;
+      c = c.offsetParent;
+    }
+    if (rtl) {
+      offsetX -= objElement.offsetWidth;
+    }
+    s.left = offsetX + 'px';
+    s.top = t + 'px';
+    s.display = 'block';
+    s.border = '1px solid #000000';
+  }
+};
+function posObjs() {
+};
+posObjs();</script>
+<script type="text/javascript">activeSheetId = '0'; switchToSheet('0');</script></body></html>

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,6 @@
-var yargs = require('yargs');
+var yargs = require('yargs')
+  .boolean('verbose')
+  .alias('verbose', 'v');
 var options = yargs.argv;
 var table = require('../');
 var ndjson = require('ndjson');


### PR DESCRIPTION
The following options may be specified either as a function or a string, which is interpreted as a CSS selector. Currently, only selectors supported by [cssauron](https://www.npmjs.com/package/cssauron) will work.
- `table`: only parse the first table that matches this selector, e.g. `.statistics` (default: `"table"`)
- `headerRow`: only parse column headers from rows that match this filter (default: `"tr"`)
- `headerCell`: only parse column header cells from elements that match this filter (default: `"th, td"`)
- `bodyRow`: only parse body (data) rows that match this filter (default: `"tr"`)
- `bodyCell`: only parse body (data) cells that match this filter (default: `"th, td"`)

Also, adding support a `verbose` option to toggle the output of debug messages via `console.warn()`.

You may also provide a `preset` option. The only value currently supported is `"google-html"`.

Fixes #4.
